### PR TITLE
add clamping and thresholding logic to match-cli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-logr/zerologr v1.2.0
 	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/optable/match v0.0.0-20211119141238-b4b571f00d8b
-	github.com/optable/match-api v1.0.0
+	github.com/optable/match-api v1.0.1-0.20211122202249-642f58cc4d19
 	github.com/rs/zerolog v1.25.0
 	github.com/segmentio/ksuid v1.0.3
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/optable/match v0.0.0-20211119141238-b4b571f00d8b h1:x5zNGoEYCjevFQZz3
 github.com/optable/match v0.0.0-20211119141238-b4b571f00d8b/go.mod h1:FAsQ2LU5JtQCWBM8FKofE2dx4+GI+KS/XORPxK0w5o4=
 github.com/optable/match-api v1.0.0 h1:qiQ77eGC0A/oY8UT4PsQ4zT9ATMLa5cnv6BYNpK+mgM=
 github.com/optable/match-api v1.0.0/go.mod h1:Nnv8Zcs4p71WDSgFy/FcjxnHBL+Dane7cimb4+SJDEA=
+github.com/optable/match-api v1.0.1-0.20211122202249-642f58cc4d19 h1:7IaJ84o+RFC1SspsUwBM7DVvKLOQGjvZ6qfH1IpBJNo=
+github.com/optable/match-api v1.0.1-0.20211122202249-642f58cc4d19/go.mod h1:Nnv8Zcs4p71WDSgFy/FcjxnHBL+Dane7cimb4+SJDEA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -5,15 +5,17 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 
+	v1 "github.com/optable/match-api/match/v1"
 	"github.com/rs/zerolog"
 )
 
 //GetInputChannel reads identifiers from a file to a channel
-func GenInputChannel(ctx context.Context, f *os.File) (int64, <-chan []byte, error) {
-	n, err := count(f)
+func GenInputChannel(ctx context.Context, f *os.File) (int64, *v1.Insights, <-chan []byte, error) {
+	n, insight, err := count(f)
 	if err != nil {
-		return n, nil, err
+		return n, nil, nil, err
 	}
 
 	// rewind
@@ -42,22 +44,46 @@ func GenInputChannel(ctx context.Context, f *os.File) (int64, <-chan []byte, err
 		}
 	}()
 
-	return n, identifiers, nil
+	return n, insight, identifiers, nil
 }
 
-//count returns number of lines in file
-func count(r io.Reader) (int64, error) {
+// count returns number of lines in file, as well as the
+// number of each id type
+func count(r io.Reader) (int64, *v1.Insights, error) {
 	var n int64
+	var insight v1.Insights
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
+		s := string(scanner.Bytes())
+		switch {
+		case strings.HasPrefix(s, "e:"):
+			insight.Emails++
+		case strings.HasPrefix(s, "p:"):
+			insight.PhoneNumbers++
+		case strings.HasPrefix(s, "i4:"):
+			insight.Ipv4S++
+		case strings.HasPrefix(s, "i6:"):
+			insight.Ipv6S++
+		case strings.HasPrefix(s, "a:"):
+			insight.AppleIdfas++
+		case strings.HasPrefix(s, "g:"):
+			insight.GoogleGaids++
+		case strings.HasPrefix(s, "r:"):
+			insight.RokuRidas++
+		case strings.HasPrefix(s, "s:"):
+			insight.SamsungTifas++
+		case strings.HasPrefix(s, "f:"):
+			insight.AmazonAfais++
+		}
+		//TODO: do we handle invalid prefix type?
 		n++
 	}
 
 	if err := scanner.Err(); err != nil {
-		return n, err
+		return n, nil, err
 	}
 
-	return n, nil
+	return n, &insight, nil
 }
 
 // safeReadLine reads each line until a newline character and returns
@@ -70,4 +96,42 @@ func safeReadLine(r *bufio.Reader) (line []byte, err error) {
 		line = line[:len(line)-1]
 	}
 	return
+}
+
+// clamp changes the received numbers from the partner which can have differential privacy noise in them,
+// meaning the numbers could be negative or exceed the total number of IDs.
+// We want to normalize the number to be 0 <= candidate <= maxValue
+func clamp(max, n int64) int64 {
+	if n < 0 {
+		return 0
+	}
+	if n > max {
+		return max
+	}
+	return n
+}
+
+func ClampMatchResult(result *v1.ExternalMatchResult, srcInsight *v1.Insights) {
+	for idkind := range v1.IdKind_name {
+		switch v1.IdKind(idkind) {
+		case v1.IdKind_ID_KIND_EMAIL_HASH:
+			result.Insights.Emails = clamp(srcInsight.Emails, result.Insights.Emails)
+		case v1.IdKind_ID_KIND_PHONE_NUMBER:
+			result.Insights.PhoneNumbers = clamp(srcInsight.PhoneNumbers, result.Insights.PhoneNumbers)
+		case v1.IdKind_ID_KIND_IPV4:
+			result.Insights.Ipv4S = clamp(srcInsight.Ipv4S, result.Insights.Ipv4S)
+		case v1.IdKind_ID_KIND_IPV6:
+			result.Insights.Ipv6S = clamp(srcInsight.Ipv6S, result.Insights.Ipv6S)
+		case v1.IdKind_ID_KIND_APPLE_IDFA:
+			result.Insights.AppleIdfas = clamp(srcInsight.AppleIdfas, result.Insights.AppleIdfas)
+		case v1.IdKind_ID_KIND_GOOGLE_GAID:
+			result.Insights.GoogleGaids = clamp(srcInsight.GoogleGaids, result.Insights.GoogleGaids)
+		case v1.IdKind_ID_KIND_ROKU_RIDA:
+			result.Insights.RokuRidas = clamp(srcInsight.RokuRidas, result.Insights.RokuRidas)
+		case v1.IdKind_ID_KIND_SAMSUNG_TIFA:
+			result.Insights.SamsungTifas = clamp(srcInsight.SamsungTifas, result.Insights.SamsungTifas)
+		case v1.IdKind_ID_KIND_AMAZON_AFAI:
+			result.Insights.AmazonAfais = clamp(srcInsight.AmazonAfais, result.Insights.AmazonAfais)
+		}
+	}
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -111,27 +111,41 @@ func clamp(max, n int64) int64 {
 	return n
 }
 
-func ClampMatchResult(result *v1.ExternalMatchResult, srcInsight *v1.Insights) {
+func threshold(n int64, threshold int32) int64 {
+	// no thresholding
+	if int64(threshold) == 0 {
+		return n
+	}
+	if n < int64(threshold) {
+		return 0
+	}
+	return n
+}
+
+// ThresholdAndClampMatchResult modifies the received match result insight numbers
+// by applying a threshold on the received value first, if the value is less than the threshold,
+// it will be set to 0. Afterwards, we clamp the thresholded value.
+func ThresholdAndClampMatchResult(result *v1.ExternalMatchResult, srcInsight *v1.Insights) {
 	for idkind := range v1.IdKind_name {
 		switch v1.IdKind(idkind) {
 		case v1.IdKind_ID_KIND_EMAIL_HASH:
-			result.Insights.Emails = clamp(srcInsight.Emails, result.Insights.Emails)
+			result.Insights.Emails = clamp(srcInsight.Emails, threshold(result.Insights.Emails, result.Insights.DifferentialPrivacyThreshold))
 		case v1.IdKind_ID_KIND_PHONE_NUMBER:
-			result.Insights.PhoneNumbers = clamp(srcInsight.PhoneNumbers, result.Insights.PhoneNumbers)
+			result.Insights.PhoneNumbers = clamp(srcInsight.PhoneNumbers, threshold(result.Insights.PhoneNumbers, result.Insights.DifferentialPrivacyThreshold))
 		case v1.IdKind_ID_KIND_IPV4:
-			result.Insights.Ipv4S = clamp(srcInsight.Ipv4S, result.Insights.Ipv4S)
+			result.Insights.Ipv4S = clamp(srcInsight.Ipv4S, threshold(result.Insights.Ipv4S, result.Insights.DifferentialPrivacyThreshold))
 		case v1.IdKind_ID_KIND_IPV6:
-			result.Insights.Ipv6S = clamp(srcInsight.Ipv6S, result.Insights.Ipv6S)
+			result.Insights.Ipv6S = clamp(srcInsight.Ipv6S, threshold(result.Insights.Ipv6S, result.Insights.DifferentialPrivacyThreshold))
 		case v1.IdKind_ID_KIND_APPLE_IDFA:
-			result.Insights.AppleIdfas = clamp(srcInsight.AppleIdfas, result.Insights.AppleIdfas)
+			result.Insights.AppleIdfas = clamp(srcInsight.AppleIdfas, threshold(result.Insights.AppleIdfas, result.Insights.DifferentialPrivacyThreshold))
 		case v1.IdKind_ID_KIND_GOOGLE_GAID:
-			result.Insights.GoogleGaids = clamp(srcInsight.GoogleGaids, result.Insights.GoogleGaids)
+			result.Insights.GoogleGaids = clamp(srcInsight.GoogleGaids, threshold(result.Insights.GoogleGaids, result.Insights.DifferentialPrivacyThreshold))
 		case v1.IdKind_ID_KIND_ROKU_RIDA:
-			result.Insights.RokuRidas = clamp(srcInsight.RokuRidas, result.Insights.RokuRidas)
+			result.Insights.RokuRidas = clamp(srcInsight.RokuRidas, threshold(result.Insights.RokuRidas, result.Insights.DifferentialPrivacyThreshold))
 		case v1.IdKind_ID_KIND_SAMSUNG_TIFA:
-			result.Insights.SamsungTifas = clamp(srcInsight.SamsungTifas, result.Insights.SamsungTifas)
+			result.Insights.SamsungTifas = clamp(srcInsight.SamsungTifas, threshold(result.Insights.SamsungTifas, result.Insights.DifferentialPrivacyThreshold))
 		case v1.IdKind_ID_KIND_AMAZON_AFAI:
-			result.Insights.AmazonAfais = clamp(srcInsight.AmazonAfais, result.Insights.AmazonAfais)
+			result.Insights.AmazonAfais = clamp(srcInsight.AmazonAfais, threshold(result.Insights.AmazonAfais, result.Insights.DifferentialPrivacyThreshold))
 		}
 	}
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -72,10 +72,52 @@ func TestClampMatchResult(t *testing.T) {
 	received.Insights.PhoneNumbers = -2
 	received.Insights.SamsungTifas = 2
 	received.Insights.Ipv4S = 0
+	received.Insights.DifferentialPrivacyThreshold = 0
 
-	ClampMatchResult(&received, srcInsight)
+	ThresholdAndClampMatchResult(&received, srcInsight)
 	if received.Insights.Emails != srcInsight.Emails || received.Insights.PhoneNumbers != 0 ||
 		received.Insights.SamsungTifas != srcInsight.SamsungTifas || received.Insights.Ipv4S != 0 {
+		t.Fatal("clamp result failed")
+	}
+}
+
+func TestClampAndThresholdMatchResult(t *testing.T) {
+	_, srcInsight, err := count(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	received := v1.ExternalMatchResult{Insights: &v1.Insights{}}
+
+	received.Insights.Emails = 5
+	received.Insights.PhoneNumbers = -2
+	received.Insights.SamsungTifas = 2
+	received.Insights.Ipv4S = 0
+	received.Insights.DifferentialPrivacyThreshold = 2
+
+	ThresholdAndClampMatchResult(&received, srcInsight)
+	if received.Insights.Emails != srcInsight.Emails || received.Insights.Ipv4S != 0 ||
+		received.Insights.Ipv6S != 0 || received.Insights.PhoneNumbers != 0 ||
+		received.Insights.AppleIdfas != 0 || received.Insights.SamsungTifas != srcInsight.SamsungTifas ||
+		received.Insights.GoogleGaids != 0 || received.Insights.RokuRidas != 0 || received.Insights.AmazonAfais != 0 {
+		t.Fatal("clamp result failed")
+	}
+
+	src := v1.Insights{}
+	src.Emails = 1001
+	src.PhoneNumbers = 570
+	src.GoogleGaids = 2
+
+	received.Insights.Emails = 600
+	received.Insights.PhoneNumbers = 500
+	received.Insights.GoogleGaids = -2
+	received.Insights.DifferentialPrivacyThreshold = 600
+	t.Log(received.Insights.PhoneNumbers)
+
+	ThresholdAndClampMatchResult(&received, &src)
+	t.Log(received.Insights.PhoneNumbers)
+	if received.Insights.Emails != 600 || received.Insights.PhoneNumbers != 0 ||
+		received.Insights.GoogleGaids != 0 {
 		t.Fatal("clamp result failed")
 	}
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,81 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	v1 "github.com/optable/match-api/match/v1"
+)
+
+var input = `i4:8.8.8.8
+p:18055554321
+i4:1.1.1.1
+i6:1.1.1.1.1.1
+p:12125551122
+e:920d0b248f5eea3b9c4838867d8dc8392e8522f2f89f7dc67a3f0e3d52ba2c14
+e:920d1212465e48d839b47102826b8c574959e5fcc6bf0fe4f888811a6d14c8de
+a:214as2d4asasdasd
+e:920d43ae6aebac63291f0476a63f9dc3d3cd7d3b071673c7f145f58e893740f4
+r:4as6d4a3s4dasdad
+g:a2354ds35as4d3asd
+g:5a4d35a4d35as4d3a
+f:21312230udklsjfaklhjda
+s:alhjklashsjklfahs23e0923ur420`
+
+func TestCount(t *testing.T) {
+	n, insight, err := count(strings.NewReader("e:920d43ae6aebac63291f0476a63f9dc3d3cd7d3b071673c7f145f58e893740f4"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 || insight.Emails != 1 {
+		t.Fatalf("count failed")
+	}
+
+	n, insight, err = count(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 14 || insight.Emails != 3 || insight.Ipv4S != 2 || insight.Ipv6S != 1 ||
+		insight.PhoneNumbers != 2 || insight.AppleIdfas != 1 || insight.SamsungTifas != 1 ||
+		insight.GoogleGaids != 2 || insight.RokuRidas != 1 || insight.AmazonAfais != 1 {
+		t.Fatalf("count failed")
+	}
+}
+
+func TestClamp(t *testing.T) {
+	max := int64(10)
+	clamped := clamp(max, -1)
+	if clamped != 0 {
+		t.Fatalf("clamp failed, want %d, got %d", 0, clamped)
+	}
+
+	clamped = clamp(max, 11)
+	if clamped != max {
+		t.Fatalf("clamp failed, want %d, got %d", max, clamped)
+	}
+
+	clamped = clamp(max, 1)
+	if clamped != 1 {
+		t.Fatalf("clamp failed, want %d, got %d", 1, clamped)
+	}
+}
+
+func TestClampMatchResult(t *testing.T) {
+	_, srcInsight, err := count(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	received := v1.ExternalMatchResult{Insights: &v1.Insights{}}
+
+	received.Insights.Emails = 5
+	received.Insights.PhoneNumbers = -2
+	received.Insights.SamsungTifas = 2
+	received.Insights.Ipv4S = 0
+
+	ClampMatchResult(&received, srcInsight)
+	if received.Insights.Emails != srcInsight.Emails || received.Insights.PhoneNumbers != 0 ||
+		received.Insights.SamsungTifas != srcInsight.SamsungTifas || received.Insights.Ipv4S != 0 {
+		t.Fatal("clamp result failed")
+	}
+}

--- a/pkg/cli/match.go
+++ b/pkg/cli/match.go
@@ -252,11 +252,11 @@ func (m *MatchRunCmd) Run(cli *CliContext) error {
 	defer cancel()
 	info(ctx).Msgf("running match %s with a timeout of %v", m.MatchID, m.RunTimeout)
 
-	n, records, err := util.GenInputChannel(ctx, m.File)
+	n, srcInsight, records, err := util.GenInputChannel(ctx, m.File)
 	if err != nil {
 		return fmt.Errorf("failed to load record file %s : %w", m.File.Name(), err)
 	}
-	info(ctx).Msgf("loaded %d records from %s", n, m.File.Name())
+	info(ctx).Msgf("loaded %d records from %s, with the following breakdown: %v", n, m.File.Name(), srcInsight)
 
 	partner := cli.config.findPartner(m.Partner)
 	if partner == nil {
@@ -305,5 +305,6 @@ func (m *MatchRunCmd) Run(cli *CliContext) error {
 
 	info(ctx).Msg("got results from /match/get-result")
 
+	util.ClampMatchResult(result, srcInsight)
 	return printJson(matchResultFromProto(result))
 }

--- a/pkg/cli/match.go
+++ b/pkg/cli/match.go
@@ -305,6 +305,7 @@ func (m *MatchRunCmd) Run(cli *CliContext) error {
 
 	info(ctx).Msg("got results from /match/get-result")
 
-	util.ClampMatchResult(result, srcInsight)
+	// apply threshold on received insights and clamp it with src insight counts
+	util.ThresholdAndClampMatchResult(result, srcInsight)
 	return printJson(matchResultFromProto(result))
 }


### PR DESCRIPTION
On `match run`, in addition to counting the total number of lines in an input file, it also counts the number of each id type.
After obtaining the match result from partner, it applies a threshold on the received insight values and then subsequently clamps the values with the initial count of each ID type.
This means in terms of pseudocode: 
```
clamp(srcInsights, threshold(matchResult.Insights, matchResult.Insights.DifferentialPrivacyThreshold))
```

Questions:
* should we error on invalid prefix type and exit early, now that we are type aware?
* should I keep the breakdown of the input file in log?

example (prior to this change):
```
$ bin/match-cli match run jl1 <match-result-uuid> <input-file>
2021-11-23T11:33:08-05:00 INF loaded 3008 records from <input-file> cli=match-cli
{"time":<time-stamp>,"id":id,"state":"completed","results":{"emails":3017,"ipv4s":3,"phone_numbers":3}}
```

with the new changes and no threshold:
```
$ bin/match-cli match run jl1 <match-result-uuid> <input-file>
2021-11-23T11:33:08-05:00 INF loaded 3008 records from <input-file>, with the following breakdown: emails:3000 ipv4s:3 phone_numbers:4 cli=match-clicli=match-cli
{"time":<time-stamp>,"id":<id>,"state":"completed","results":{"emails":3000,"ipv4s":3,"phone_numbers":3}}
```

with threshold set to 1:
```
$ bin/match-cli match run jl1 <match-result-uuid> <input-file>
2021-11-23T13:27:49-05:00 INF loaded 3008 records from <input-file>, with the following breakdown: emails:3000 ipv4s:3 phone_numbers:4 cli=match-clicli=match-cli
{"time":<time-stamp>,"id":<id>,"state":"completed","results":{"emails":3000,"ipv4s":3,"phone_numbers":3,"differential_privacy_threshold":1}}
```

with threshold set to 1000:
```
$ bin/match-cli match run jl1 <match-result-uuid> <input-file>
2021-11-23T13:26:53-05:00 INF loaded 3008 records from <input-file>, with the following breakdown: emails:3000 ipv4s:3 phone_numbers:4 cli=match-clicli=match-cli
{"time":<time-stamp>,"id":<id>,"state":"completed","results":{"emails":3000,"differential_privacy_threshold":1000}}
```