### PR TITLE
build universal binary for mac OS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,7 @@ jobs:
           name: "Publish Release on GitHub"
           command: |
             go get github.com/github-release/github-release
-            github-release upload --user optable --repo match-cli --tag ${CIRCLE_TAG} --name "match-cli-darwin-amd64" --file ./release/match-cli-darwin-amd64
-            github-release upload --user optable --repo match-cli --tag ${CIRCLE_TAG} --name "match-cli-darwin-arm64" --file ./release/match-cli-darwin-arm64
+            github-release upload --user optable --repo match-cli --tag ${CIRCLE_TAG} --name "match-cli-darwin" --file ./release/match-cli-darwin
             github-release upload --user optable --repo match-cli --tag ${CIRCLE_TAG} --name "match-cli-linux-amd64" --file ./release/match-cli-linux-amd64
             github-release upload --user optable --repo match-cli --tag ${CIRCLE_TAG} --name "match-cli-windows-amd64.exe" --file ./release/match-cli-windows-amd64.exe
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,13 @@ build:
 	$(GO) build -ldflags "-X github.com/optable/match-cli/pkg/cli.version=${BUILD_VERSION}" -o bin/match-cli cmd/cli/main.go
 
 .PHONY: release
-release: darwin-amd64 darwin-arm64 linux windows
+release: darwin linux windows
+
+.PHONY: darwin
+darwin: darwin-amd64 darwin-arm64
+	$(GO) install github.com/randall77/makefat@latest
+	makefat release/match-cli-darwin release/match-cli-darwin-amd64 release/match-cli-darwin-arm64
+	rm release/match-cli-darwin-amd64 release/match-cli-darwin-arm64
 
 .PHONY: darwin-amd64
 darwin-amd64:


### PR DESCRIPTION
This builds a universal binary for mac os, which contains both the amd64 arch and arm64 arch.
```
file release/match-cli-darwin
release/match-cli-darwin: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
release/match-cli-darwin (for architecture x86_64):	Mach-O 64-bit executable x86_64
release/match-cli-darwin (for architecture arm64):	Mach-O 64-bit executable arm64
```