### PR TITLE
Stop using the slug as issuer and use pubkey instead

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-logr/zerologr v1.2.1
 	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/optable/match v1.1.1
-	github.com/optable/match-api v1.3.1
+	github.com/optable/match-api v1.3.0
 	github.com/rs/zerolog v1.25.0
 	github.com/segmentio/ksuid v1.0.3
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/gtank/ristretto255 v0.1.2 h1:JEqUCPA1NvLq5DwYtuzigd7ss8fwbYay9fi4/5uM
 github.com/gtank/ristretto255 v0.1.2/go.mod h1:Ph5OpO6c7xKUGROZfWVLiJf9icMDwUeIvY4OmlYW69o=
 github.com/optable/match v1.1.1 h1:uXbYmoZkz+LIJY/g5nPnBOySYjs4dZAXZL+4+tQzGwI=
 github.com/optable/match v1.1.1/go.mod h1:MRELiUJ6TJwfnbb6WP25iWIRiS7GiZOVMKLIcYiL+30=
-github.com/optable/match-api v1.3.1 h1:uQwijpBYiVEiHx/HOG371C1BCk3D/N2u+q1xk2zhNA0=
-github.com/optable/match-api v1.3.1/go.mod h1:Nnv8Zcs4p71WDSgFy/FcjxnHBL+Dane7cimb4+SJDEA=
+github.com/optable/match-api v1.3.0 h1:iD5Y94mQ0JdbtOjxNmQ/pdkS1DINnYB31SZi8ZAXhLo=
+github.com/optable/match-api v1.3.0/go.mod h1:Nnv8Zcs4p71WDSgFy/FcjxnHBL+Dane7cimb4+SJDEA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -56,7 +56,7 @@ type PartnerConfig struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	URL         string `json:"url"`
-	Id          string `json:"id"`
+	PublicKey   string `json:"public_key"`
 	PrivateKey  string `json:"private_key"`
 }
 
@@ -74,12 +74,10 @@ func (partner *PartnerConfig) ParsedPrivateKey() (*ecdsa.PrivateKey, error) {
 }
 
 func (partner *PartnerConfig) NewToken(expireAt time.Duration) (string, error) {
-	claims := jwt.StandardClaims{
-		Issuer:    partner.Id,
+	tok := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.StandardClaims{
+		Issuer:    partner.PublicKey,
 		ExpiresAt: time.Now().Add(expireAt).Unix(),
-	}
-
-	tok := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	})
 
 	parsedKey, err := partner.ParsedPrivateKey()
 	if err != nil {


### PR DESCRIPTION
Breaking change for v2 release.

Change configuration format to store public key directly in config file and use it as the issuer. Server must use the public key as an identifier to lookup existing partnership.