### PR TITLE
Add NetID TPID as a matchable identifier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-logr/zerologr v1.2.1
 	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/optable/match v1.1.1
-	github.com/optable/match-api v1.3.0
+	github.com/optable/match-api v1.4.1
 	github.com/rs/zerolog v1.25.0
 	github.com/segmentio/ksuid v1.0.3
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/go-logr/zerologr v1.2.1/go.mod h1:O82obOiXzyxiBNgAMRT1m+XbOvY8K18Kf6X
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -30,8 +31,8 @@ github.com/gtank/ristretto255 v0.1.2 h1:JEqUCPA1NvLq5DwYtuzigd7ss8fwbYay9fi4/5uM
 github.com/gtank/ristretto255 v0.1.2/go.mod h1:Ph5OpO6c7xKUGROZfWVLiJf9icMDwUeIvY4OmlYW69o=
 github.com/optable/match v1.1.1 h1:uXbYmoZkz+LIJY/g5nPnBOySYjs4dZAXZL+4+tQzGwI=
 github.com/optable/match v1.1.1/go.mod h1:MRELiUJ6TJwfnbb6WP25iWIRiS7GiZOVMKLIcYiL+30=
-github.com/optable/match-api v1.3.0 h1:iD5Y94mQ0JdbtOjxNmQ/pdkS1DINnYB31SZi8ZAXhLo=
-github.com/optable/match-api v1.3.0/go.mod h1:Nnv8Zcs4p71WDSgFy/FcjxnHBL+Dane7cimb4+SJDEA=
+github.com/optable/match-api v1.4.1 h1:gSDnLFkFzcuh5jlrKMseQSBTxlZwYGOyVd7tuTtVWuE=
+github.com/optable/match-api v1.4.1/go.mod h1:Nnv8Zcs4p71WDSgFy/FcjxnHBL+Dane7cimb4+SJDEA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -9,7 +9,7 @@ import (
 	v1 "github.com/optable/match-api/match/v1"
 )
 
-var validIdentifiersPrefix = map[string]string{"emails": "e:", "phoneNumbers": "p:", "ipv4S": "i4:", "ipv6S": "i6:", "appleIdfas": "a:", "googleGaids": "g:", "rokuRidas": "r:", "samsungTifas": "s:", "amazonAfais": "f:"}
+var validIdentifiersPrefix = map[string]string{"emails": "e:", "phoneNumbers": "p:", "ipv4S": "i4:", "ipv6S": "i6:", "appleIdfas": "a:", "googleGaids": "g:", "rokuRidas": "r:", "samsungTifas": "s:", "amazonAfais": "f:", "netidTpids": "n:"}
 
 //GetInputChannel reads identifiers from a file to a channel
 func GetInputChannel(ctx context.Context, uniqueIdentifiersInFile map[string]bool) (<-chan []byte, error) {
@@ -49,6 +49,8 @@ func GetInsights(uniqueIdentifiersInFile map[string]bool) *v1.Insights {
 			insight.SamsungTifas++
 		case strings.HasPrefix(identifier, validIdentifiersPrefix["amazonAfais"]):
 			insight.AmazonAfais++
+		case strings.HasPrefix(identifier, validIdentifiersPrefix["netidTpids"]):
+			insight.NetidTpids++
 		}
 	}
 	return &insight
@@ -122,6 +124,8 @@ func ThresholdAndClampMatchResult(result *v1.ExternalMatchResult, srcInsight *v1
 			result.Insights.SamsungTifas = clamp(srcInsight.SamsungTifas, threshold(result.Insights.SamsungTifas, result.Insights.DifferentialPrivacyThreshold))
 		case v1.IdKind_ID_KIND_AMAZON_AFAI:
 			result.Insights.AmazonAfais = clamp(srcInsight.AmazonAfais, threshold(result.Insights.AmazonAfais, result.Insights.DifferentialPrivacyThreshold))
+		case v1.IdKind_ID_KIND_NETID_TPID:
+			result.Insights.NetidTpids = clamp(srcInsight.NetidTpids, threshold(result.Insights.NetidTpids, result.Insights.DifferentialPrivacyThreshold))
 		}
 	}
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -24,6 +24,7 @@ g:a2354ds35as4d3asd
 g:5a4d35a4d35as4d3a
 f:21312230udklsjfaklhjda
 s:alhjklashsjklfahs23e0923ur420
+n:3g---iNqaaXav5Wzp8m9h7mg68ChHKV9IDjaMgpTRKFkLSKN4SM3hMTvsviB1riileyz0A
 invalidIdentifier`
 
 var inputMap = map[string]bool{
@@ -41,6 +42,7 @@ var inputMap = map[string]bool{
 	"g:5a4d35a4d35as4d3a":             true,
 	"f:21312230udklsjfaklhjda":        true,
 	"s:alhjklashsjklfahs23e0923ur420": true,
+	"n:3g---iNqaaXav5Wzp8m9h7mg68ChHKV9IDjaMgpTRKFkLSKN4SM3hMTvsviB1riileyz0A": true,
 }
 
 func TestClamp(t *testing.T) {
@@ -131,7 +133,7 @@ func TestGetInputChannel(t *testing.T) {
 		chanLength++
 	}
 
-	if chanLength != 14 {
+	if chanLength != 15 {
 		t.Fatal("get input channel failed")
 	}
 }
@@ -153,7 +155,7 @@ func TestGetUniqueIdentifiersInFile(t *testing.T) {
 		t.Fatal("Invalid identifier found")
 	}
 
-	if len(uniqueIdentifiersInFile) != 14 {
+	if len(uniqueIdentifiersInFile) != 15 {
 		t.Fatal("get unique elements failed")
 	}
 }
@@ -163,7 +165,8 @@ func TestGetInsights(t *testing.T) {
 
 	if insight.Emails != 3 || insight.Ipv4S != 2 || insight.Ipv6S != 1 ||
 		insight.PhoneNumbers != 2 || insight.AppleIdfas != 1 || insight.SamsungTifas != 1 ||
-		insight.GoogleGaids != 2 || insight.RokuRidas != 1 || insight.AmazonAfais != 1 {
+		insight.GoogleGaids != 2 || insight.RokuRidas != 1 || insight.AmazonAfais != 1 ||
+		insight.NetidTpids != 1 {
 		t.Fatalf("get insights and identifiers failed")
 	}
 }


### PR DESCRIPTION
NetID TPID is a primarily German identifier that consists of a base64 web-safe encoded value which must have an encoded length of 70 characters. The prefix used is `n:`.